### PR TITLE
Add critique loop to review skill

### DIFF
--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -172,21 +172,40 @@ Once you've confirmed no fundamental issues exist:
 
 ### Phase 2: Critique
 
-After completing the initial review, launch a **critique pass** to improve review quality.
+After completing the initial review, **launch a subagent using the Task tool** to critique the review. Using a separate agent provides a genuinely fresh perspective.
 
-The critique examines your own review output and looks for:
+**You MUST use the Task tool** with `subagent_type: "general-purpose"` to run the critique. Do not attempt to critique your own review directly.
+
+Provide the subagent with:
+1. The original code being reviewed (file paths or content)
+2. Your complete initial review output
+3. Instructions to critique the review
+
+The critique subagent examines the initial review and looks for:
 
 - **Missed issues** - Problems in the code that the initial review didn't catch
 - **Incorrect severity** - Findings that should be upgraded or downgraded
 - **False positives** - Findings that aren't actually problems on closer inspection
 - **Incomplete reasoning** - Suggestions that lack proper justification
 
-To perform the critique:
+Example Task tool invocation:
 
-1. Re-read the original code with fresh eyes
-2. Compare against your initial findings
-3. Ask: "What did I miss? What did I get wrong?"
-4. Document any additional findings or corrections
+```
+Task tool with subagent_type: "general-purpose"
+prompt: |
+  Critique this code review. You have access to the original code and the review output.
+
+  Files to review: <list of files>
+
+  Initial review output:
+  <paste your review here>
+
+  Your job is to find what the review missed or got wrong:
+  1. Read the original code files
+  2. Compare against the review findings
+  3. Identify: missed issues, incorrect severity, false positives, incomplete reasoning
+  4. Return your critique as a structured list of findings
+```
 
 ### Phase 3: Synthesis
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -138,9 +138,13 @@ Recognition is valuable—review isn't only about finding problems.
 
 ## Review Approach
 
-Follow this three-step process to review code efficiently:
+Follow this multi-phase process to produce thorough reviews:
 
-### Step 1: Assess the Big Picture
+### Phase 1: Initial Review
+
+Conduct a complete review of the code:
+
+#### Step 1: Assess the Big Picture
 
 Before diving into details, ask: **Does this change make sense at all?**
 
@@ -150,7 +154,7 @@ Before diving into details, ask: **Does this change make sense at all?**
 
 If there are major design problems, raise them immediately. Don't let the developer build more work on a problematic foundation.
 
-### Step 2: Examine Core Components
+#### Step 2: Examine Core Components
 
 Identify the files containing the bulk of logical changes and review these first:
 
@@ -158,13 +162,51 @@ Identify the files containing the bulk of logical changes and review these first
 - Major issues here often make other review comments irrelevant
 - Consider reviewing tests before implementation to understand intended behaviour
 
-### Step 3: Review Remaining Files Systematically
+#### Step 3: Review Remaining Files Systematically
 
 Once you've confirmed no fundamental issues exist:
 
 - Work through remaining files in a logical order
 - Look for issues in each review category
 - Ensure nothing is missed
+
+### Phase 2: Critique
+
+After completing the initial review, launch a **critique pass** to improve review quality.
+
+The critique examines your own review output and looks for:
+
+- **Missed issues** - Problems in the code that the initial review didn't catch
+- **Incorrect severity** - Findings that should be upgraded or downgraded
+- **False positives** - Findings that aren't actually problems on closer inspection
+- **Incomplete reasoning** - Suggestions that lack proper justification
+
+To perform the critique:
+
+1. Re-read the original code with fresh eyes
+2. Compare against your initial findings
+3. Ask: "What did I miss? What did I get wrong?"
+4. Document any additional findings or corrections
+
+### Phase 3: Synthesis
+
+Combine the initial review with critique findings into a final output:
+
+1. **Merge findings** - Add any new issues identified during critique
+2. **Resolve conflicts** - When initial review and critique disagree:
+   - Prefer higher severity (err on the side of caution)
+   - Note disagreements with context when relevant
+3. **Remove false positives** - Drop findings the critique identified as incorrect
+4. **Annotate critique contributions** - Mark findings that came from the critique phase with `[Critique]`
+
+#### Deciding on Additional Passes
+
+After synthesis, decide whether another critique pass would add value:
+
+- **Run another pass if:** The critique found significant issues, suggesting more may be lurking
+- **Stop if:** The critique pass found nothing substantial or only minor adjustments
+
+Limit to a maximum of 2 critique passes to avoid diminishing returns.
 
 ## Output Format
 
@@ -179,6 +221,7 @@ Structure review findings clearly:
 
 ### Design
 - [Severity] file:line - Description
+- [Critique] [Severity] file:line - Description (added by critique pass)
 
 ### Functionality
 - [Severity] file:line - Description
@@ -211,6 +254,12 @@ Structure review findings clearly:
 
 [Brief explanation of verdict]
 ```
+
+### Annotation Format
+
+- **Initial findings**: Listed without prefix, e.g., `[Blocking] file:line - Description`
+- **Critique findings**: Prefixed with `[Critique]`, e.g., `[Critique] [Suggestion] file:line - Description`
+- **Severity adjustments**: Note when critique changed severity, e.g., `[Upgraded from Suggestion] [Blocking] file:line - Description`
 
 Omit empty categories. Group related findings together.
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -196,9 +196,12 @@ Parameters:
   subagent_type: "general-purpose"
   description: "Critique code review"
   prompt: |
-    Critique this code review. You have access to read the original code files.
+    Critique this code review. You have access to Bash and Read tools.
 
-    Files under review (use the Read tool to examine these):
+    To see exactly what changed, run:
+    git diff main...HEAD
+
+    Files under review (use Read to examine full context if needed):
     - src/components/Button.tsx
     - src/utils/validation.ts
 
@@ -210,13 +213,14 @@ Parameters:
     [include all findings from your initial review]
 
     Your job is to find what the review missed or got wrong:
-    1. Read each of the original code files listed above
-    2. Compare the code against the review findings
-    3. Identify: missed issues, incorrect severity, false positives, incomplete reasoning
-    4. Return your critique as a structured list of findings
+    1. Run git diff to see the actual changes
+    2. Read full files if you need more context
+    3. Compare the changes against the review findings
+    4. Identify: missed issues, incorrect severity, false positives, incomplete reasoning
+    5. Return your critique as a structured list of findings
 ```
 
-The subagent has full access to the Read tool, so provide file paths rather than inlining content. This keeps the prompt concise and allows the subagent to examine the code directly.
+The subagent has access to Bash (for `git diff`) and Read tools. Using `git diff main...HEAD` shows exactly what changed, which is more focused than reading entire files. Use Read for additional context when needed.
 
 ### Phase 3: Synthesis
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -188,44 +188,55 @@ The critique subagent examines the initial review and looks for:
 - **False positives** - Findings that aren't actually problems on closer inspection
 - **Incomplete reasoning** - Suggestions that lack proper justification
 
-Example Task tool invocation:
+Example Task tool invocation (showing the actual tool parameters):
 
 ```
-Task tool with subagent_type: "general-purpose"
-prompt: |
-  Critique this code review. You have access to the original code and the review output.
+Tool: Task
+Parameters:
+  subagent_type: "general-purpose"
+  description: "Critique code review"
+  prompt: |
+    Critique this code review. You have access to read the original code files.
 
-  Files to review: <list of files>
+    Files under review (use the Read tool to examine these):
+    - src/components/Button.tsx
+    - src/utils/validation.ts
 
-  Initial review output:
-  <paste your review here>
+    Initial review output:
+    ## Summary
+    [paste your complete review output here]
 
-  Your job is to find what the review missed or got wrong:
-  1. Read the original code files
-  2. Compare against the review findings
-  3. Identify: missed issues, incorrect severity, false positives, incomplete reasoning
-  4. Return your critique as a structured list of findings
+    ## Findings
+    [include all findings from your initial review]
+
+    Your job is to find what the review missed or got wrong:
+    1. Read each of the original code files listed above
+    2. Compare the code against the review findings
+    3. Identify: missed issues, incorrect severity, false positives, incomplete reasoning
+    4. Return your critique as a structured list of findings
 ```
+
+The subagent has full access to the Read tool, so provide file paths rather than inlining content. This keeps the prompt concise and allows the subagent to examine the code directly.
 
 ### Phase 3: Synthesis
 
 Combine the initial review with critique findings into a final output:
 
 1. **Merge findings** - Add any new issues identified during critique
-2. **Resolve conflicts** - When initial review and critique disagree:
+2. **Remove false positives** - If critique determines a finding isn't actually a problem, remove it entirely
+3. **Resolve severity conflicts** - When both agree an issue exists but disagree on severity:
    - Prefer higher severity (err on the side of caution)
    - Note disagreements with context when relevant
-3. **Remove false positives** - Drop findings the critique identified as incorrect
 4. **Annotate critique contributions** - Mark findings that came from the critique phase with `[Critique]`
 
 #### Deciding on Additional Passes
 
 After synthesis, decide whether another critique pass would add value:
 
-- **Run another pass if:** The critique found significant issues, suggesting more may be lurking
-- **Stop if:** The critique pass found nothing substantial or only minor adjustments
+- **Run another pass if:** The critique identified any new issues (missed problems, severity upgrades, or false positives)
+- **Stop if:** The critique only confirmed existing findings without adding new ones
 
-Limit to a maximum of 2 critique passes to avoid diminishing returns.
+Limit to a maximum of 2 critique passes. Beyond this, additional passes rarely surface new issues and the cost outweighs the benefit.
 
 ## Output Format
 
@@ -240,7 +251,8 @@ Structure review findings clearly:
 
 ### Design
 - [Severity] file:line - Description
-- [Critique] [Severity] file:line - Description (added by critique pass)
+- [Critique] [Severity] file:line - Description (new issue found by critique)
+- [Upgraded from Suggestion] [Blocking] file:line - Description (severity changed by critique)
 
 ### Functionality
 - [Severity] file:line - Description


### PR DESCRIPTION
## Summary

- Adds a multi-phase review approach: Initial Review → Critique → Synthesis
- Critique phase re-examines the initial review for missed issues, incorrect severity, false positives, and incomplete reasoning
- Agent decides whether additional critique passes would add value (max 2)
- Output format updated to annotate findings from critique with `[Critique]` prefix
- `/review-pr` inherits the enhanced behaviour via delegation

Closes #18