### PR TITLE
Add edit-and-commit skill with roborev integration

### DIFF
--- a/skills/edit-and-commit/SKILL.md
+++ b/skills/edit-and-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: edit-and-commit
-description: Edit a single file and automatically commit the changes with roborev pre-commit review. Enforces atomic commits by restricting edits to one file at a time. Use when the user wants to make a focused change to a specific file and commit it.
+description: Edit files and automatically commit the changes with roborev pre-commit review. Enforces atomic commits by ensuring changes form a meaningful, coherent unit of work. Use when the user wants to make focused changes and commit them.
 user-invocable: true
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, AskUserQuestion
 ---
@@ -9,7 +9,7 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob, AskUserQuestion
 
 ## Purpose
 
-Make focused, atomic commits by editing a single file and automatically committing it with an AI code review step. This skill enforces single-file editing to maintain clean git history and uses roborev for pre-commit code review.
+Make focused, atomic commits by editing files and automatically committing them with an AI code review step. This skill ensures changes form a meaningful, coherent commit and uses roborev for pre-commit code review.
 
 ## Prerequisites
 
@@ -19,38 +19,44 @@ Make focused, atomic commits by editing a single file and automatically committi
 
 ## Workflow
 
-### Step 1: Identify the File and Change
+### Step 1: Identify the Files and Changes
 
 User will specify:
-- Which file to edit
+- Which file(s) to edit
 - What changes to make
 
 If not clear, ask for clarification.
 
+**Check coherence:**
+- Do the changes form a meaningful, atomic commit?
+- Can they be described with a single, clear commit message?
+- Are they logically related (e.g., fixing a bug, adding a feature, refactoring)?
+
 **STOP if:**
-- User requests changes to multiple files → "This skill edits one file at a time. Please specify a single file."
+- Changes are unrelated or should be separate commits → Suggest breaking into multiple commits
 - File path is ambiguous → Ask which file they mean
 
-### Step 2: Read the File
+### Step 2: Read the Files
 
 Read the current file contents to understand context:
 
 ```bash
-# Use Read tool to read the file
+# Use Read tool to read each file
 ```
 
 **STOP if:**
 - File doesn't exist → Ask if they want to create a new file (requires Write tool, not Edit)
 
-### Step 3: Make the Edit
+### Step 3: Make the Edits
 
-Use the Edit tool to make the requested changes to the file.
+Use the Edit/Write tools to make the requested changes to the files.
 
 Follow these principles:
 - Make only the requested changes
 - Preserve existing formatting and style
 - Don't add unnecessary comments or documentation
 - Don't refactor surrounding code unless requested
+- Ensure all changes are logically related and form a coherent commit
 
 ### Step 4: Run roborev Pre-commit Review
 
@@ -86,7 +92,7 @@ If adjustments needed, return to Step 3 with the additional changes.
 Once user approves, commit the changes with a descriptive message:
 
 ```bash
-git add <file-path>
+git add <file-paths...>
 git commit -m "<descriptive commit message>"
 ```
 
@@ -106,33 +112,43 @@ git commit -m "<descriptive commit message>"
 ### Step 8: Confirm Success
 
 Report back to user:
-- What file was edited
+- What files were edited
 - What changes were made
 - Commit SHA
 - Any roborev feedback that was addressed
 
-## Single-File Enforcement
+## Atomic Commit Principle
 
-This skill is designed for atomic commits. If the user asks to edit multiple files:
+This skill is designed for atomic commits - changes that form a meaningful, coherent unit of work.
 
-1. **Refuse the request** - Explain this skill handles one file at a time
-2. **Suggest alternatives**:
-   - Run the skill multiple times for separate files
-   - Use standard editing workflow for multi-file changes
-   - Consider if changes should be a single ticket with `/implement-ticket`
+**Good examples of atomic commits:**
+- Fix a bug across multiple related files
+- Add a feature that requires changes to implementation, tests, and configuration
+- Refactor a function and update all its call sites
+- Rename a symbol across multiple files
+
+**Bad examples (should be separate commits):**
+- Fix bug in auth.py AND add new feature to api.py (unrelated changes)
+- Update dependencies AND refactor database code (separate concerns)
+- Multiple unrelated bug fixes
+
+If the user asks to make unrelated changes:
+1. **Suggest splitting** - Explain these should be separate commits
+2. **Offer to do them sequentially** - Run the skill multiple times for separate commits
 
 ## Guidelines
 
 **DO**:
-- Edit exactly one file per invocation
-- Read the file first to understand context
+- Edit files that logically belong together in one commit
+- Read files first to understand context
 - Run roborev review before committing
 - Show review results to user
 - Write clear, descriptive commit messages
 - Ask user to approve before committing
+- Ensure changes form a coherent, atomic commit
 
 **DON'T**:
-- Edit multiple files in one invocation
+- Mix unrelated changes in one commit
 - Skip the roborev review step
 - Commit without user approval after review
 - Add Claude attribution to commits
@@ -196,13 +212,30 @@ Skill response:
 9. Review passes
 10. Commit: "Increase API rate limit to 500"
 
+### Example 4: Multiple related files
+
+User: "Rename the getUserData function to fetchUserData everywhere"
+
+Skill response:
+1. Search for all occurrences of getUserData
+2. Read api.py, tests.py, and utils.py (all use the function)
+3. Update function definition in api.py
+4. Update function calls in tests.py
+5. Update imports in utils.py
+6. Run roborev review
+7. Review passes
+8. Show results to user
+9. User approves
+10. Commit: "Rename getUserData to fetchUserData"
+
 ## Checklist
 
-- [ ] Identify single file to edit and what changes to make
-- [ ] Read the file to understand context
+- [ ] Identify files to edit and what changes to make
+- [ ] Verify changes form a coherent, atomic commit
+- [ ] Read files to understand context
 - [ ] Make the requested edits
 - [ ] Run roborev pre-commit review with --dirty --wait
 - [ ] Display review results to user
 - [ ] Get user approval to proceed or make adjustments
-- [ ] Commit with descriptive message (no Claude attribution)
+- [ ] Commit all changed files with descriptive message (no Claude attribution)
 - [ ] Report success with commit SHA and summary

--- a/skills/edit-and-commit/SKILL.md
+++ b/skills/edit-and-commit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: edit-and-commit
-description: Edit files and automatically commit the changes with roborev pre-commit review. Enforces atomic commits by ensuring changes form a meaningful, coherent unit of work. Use when the user wants to make focused changes and commit them.
-user-invocable: true
+description: IMPORTANT - Use this skill proactively whenever you need to edit files and commit changes. Automatically runs roborev pre-commit review and creates atomic commits. Use this instead of Edit+Bash for git operations. Required for all file modifications that should be committed.
+user-invocable: false
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, AskUserQuestion
 ---
 
@@ -9,7 +9,25 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob, AskUserQuestion
 
 ## Purpose
 
-Make focused, atomic commits by editing files and automatically committing them with an AI code review step. This skill ensures changes form a meaningful, coherent commit and uses roborev for pre-commit code review.
+**CRITICAL: Use this skill proactively whenever you need to make changes to files in a git repository.**
+
+This skill handles the complete edit-review-commit workflow:
+1. Edit files using Edit/Write tools
+2. Run roborev AI code review on changes
+3. Show review results to user
+4. Create atomic git commit with descriptive message
+
+**When to use this skill:**
+- ANY time you need to edit files and commit them
+- When implementing features or fixes
+- When refactoring code
+- When updating documentation or configuration
+- Basically: if you would normally use Edit then Bash for git commit, use this skill instead
+
+**When NOT to use this skill:**
+- Reading files only (no changes)
+- Exploring/searching codebase
+- Changes that shouldn't be committed yet
 
 ## Prerequisites
 
@@ -19,22 +37,21 @@ Make focused, atomic commits by editing files and automatically committing them 
 
 ## Workflow
 
-### Step 1: Identify the Files and Changes
+### Step 1: Plan the Changes
 
-User will specify:
-- Which file(s) to edit
+Before invoking this skill, determine:
+- Which file(s) need to be edited
 - What changes to make
-
-If not clear, ask for clarification.
+- Whether changes form an atomic commit
 
 **Check coherence:**
 - Do the changes form a meaningful, atomic commit?
 - Can they be described with a single, clear commit message?
 - Are they logically related (e.g., fixing a bug, adding a feature, refactoring)?
 
-**STOP if:**
-- Changes are unrelated or should be separate commits → Suggest breaking into multiple commits
-- File path is ambiguous → Ask which file they mean
+**If changes are unrelated:**
+- Use this skill multiple times for separate atomic commits
+- Don't mix unrelated changes in one commit
 
 ### Step 2: Read the Files
 
@@ -119,26 +136,34 @@ Report back to user:
 
 ## Atomic Commit Principle
 
-This skill is designed for atomic commits - changes that form a meaningful, coherent unit of work.
+Each invocation of this skill creates ONE atomic commit - changes that form a meaningful, coherent unit of work.
 
-**Good examples of atomic commits:**
+**Use this skill ONCE for these scenarios (one commit):**
 - Fix a bug across multiple related files
 - Add a feature that requires changes to implementation, tests, and configuration
 - Refactor a function and update all its call sites
 - Rename a symbol across multiple files
+- Update documentation for a specific feature
 
-**Bad examples (should be separate commits):**
-- Fix bug in auth.py AND add new feature to api.py (unrelated changes)
-- Update dependencies AND refactor database code (separate concerns)
-- Multiple unrelated bug fixes
+**Use this skill MULTIPLE TIMES for these scenarios (separate commits):**
+- Fix bug in auth.py AND add new feature to api.py (invoke twice: once for bug fix, once for feature)
+- Update dependencies AND refactor database code (invoke twice: once for deps, once for refactor)
+- Multiple unrelated bug fixes (invoke once per bug fix)
+- Implement feature AND update unrelated documentation (invoke twice)
 
-If the user asks to make unrelated changes:
-1. **Suggest splitting** - Explain these should be separate commits
-2. **Offer to do them sequentially** - Run the skill multiple times for separate commits
+**Decision making:**
+If you can write ONE clear commit message that describes all changes, use the skill once.
+If you need MULTIPLE commit messages to describe what you're doing, use the skill multiple times.
 
-## Guidelines
+## Guidelines for Agent
+
+**ALWAYS use this skill when:**
+- You need to edit files and commit changes
+- You're implementing a feature, fix, or refactor
+- You would normally use Edit tool + Bash git commands
 
 **DO**:
+- Use this skill proactively - don't wait for user to tell you to commit
 - Edit files that logically belong together in one commit
 - Read files first to understand context
 - Run roborev review before committing
@@ -148,6 +173,7 @@ If the user asks to make unrelated changes:
 - Ensure changes form a coherent, atomic commit
 
 **DON'T**:
+- Use Edit + Bash for git commits (use this skill instead)
 - Mix unrelated changes in one commit
 - Skip the roborev review step
 - Commit without user approval after review
@@ -175,58 +201,84 @@ Don't commit until issues are addressed or user explicitly approves anyway.
 
 User: "Fix the null pointer in auth.py line 42"
 
-Skill response:
-1. Read auth.py
-2. Make the fix to line 42
-3. Run roborev review
-4. Show review results
-5. Ask user to approve
-6. Commit: "Fix null pointer in user authentication"
+Agent thinking: I need to fix a bug in auth.py, which requires editing and committing. I should use the edit-and-commit skill.
+
+Agent action:
+1. Invokes edit-and-commit skill
+2. Skill reads auth.py
+3. Skill makes the fix to line 42
+4. Skill runs roborev review
+5. Skill shows review results to user
+6. Skill asks user to approve
+7. Skill commits: "Fix null pointer in user authentication"
 
 ### Example 2: Add a feature
 
 User: "Add logging to the database query function"
 
-Skill response:
-1. Read the file containing the database query function
-2. Add logging statements
-3. Run roborev review
-4. Review notes missing error handling
-5. Show review to user, ask if they want to add error handling too
-6. User approves proceeding
-7. Commit: "Add logging to database query function"
+Agent thinking: This requires editing code and committing it. I'll use edit-and-commit skill.
+
+Agent action:
+1. Invokes edit-and-commit skill
+2. Skill reads the database module
+3. Skill adds logging statements
+4. Skill runs roborev review
+5. Review notes missing error handling
+6. Skill shows review to user, asks if they want to add error handling
+7. User approves proceeding
+8. Skill commits: "Add logging to database query function"
 
 ### Example 3: Review finds issues
 
 User: "Update the API rate limit from 100 to 1000"
 
-Skill response:
-1. Read config file
-2. Change rate limit value
-3. Run roborev review
-4. Review warns this may cause performance issues
-5. Show warning to user
-6. User decides to use 500 instead
-7. Make adjustment
-8. Run roborev review again
-9. Review passes
-10. Commit: "Increase API rate limit to 500"
+Agent thinking: Need to update config and commit. Using edit-and-commit skill.
+
+Agent action:
+1. Invokes edit-and-commit skill
+2. Skill reads config file
+3. Skill changes rate limit value
+4. Skill runs roborev review
+5. Review warns this may cause performance issues
+6. Skill shows warning to user
+7. User decides to use 500 instead
+8. Skill makes adjustment
+9. Skill runs roborev review again
+10. Review passes
+11. Skill commits: "Increase API rate limit to 500"
 
 ### Example 4: Multiple related files
 
 User: "Rename the getUserData function to fetchUserData everywhere"
 
-Skill response:
-1. Search for all occurrences of getUserData
-2. Read api.py, tests.py, and utils.py (all use the function)
-3. Update function definition in api.py
-4. Update function calls in tests.py
-5. Update imports in utils.py
-6. Run roborev review
-7. Review passes
-8. Show results to user
-9. User approves
-10. Commit: "Rename getUserData to fetchUserData"
+Agent thinking: This affects multiple files but forms one atomic commit (rename refactor). I'll use edit-and-commit skill once for all files.
+
+Agent action:
+1. Agent searches for all occurrences of getUserData
+2. Invokes edit-and-commit skill with plan to update api.py, tests.py, utils.py
+3. Skill reads all three files
+4. Skill updates function definition in api.py
+5. Skill updates function calls in tests.py
+6. Skill updates imports in utils.py
+7. Skill runs roborev review
+8. Review passes
+9. Skill shows results to user
+10. User approves
+11. Skill commits: "Rename getUserData to fetchUserData"
+
+### Example 5: Separate atomic commits
+
+User: "Fix the auth bug and add a new API endpoint"
+
+Agent thinking: These are two unrelated changes - should be separate commits. I'll use edit-and-commit skill twice.
+
+Agent action (first commit):
+1. Invokes edit-and-commit skill for auth bug fix
+2. Skill handles auth.py edit, review, and commit
+
+Agent action (second commit):
+1. Invokes edit-and-commit skill for new API endpoint
+2. Skill handles api.py edit, review, and commit
 
 ## Checklist
 

--- a/skills/edit-and-commit/SKILL.md
+++ b/skills/edit-and-commit/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: edit-and-commit
+description: Edit a single file and automatically commit the changes with roborev pre-commit review. Enforces atomic commits by restricting edits to one file at a time. Use when the user wants to make a focused change to a specific file and commit it.
+user-invocable: true
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, AskUserQuestion
+---
+
+# Edit and Commit
+
+## Purpose
+
+Make focused, atomic commits by editing a single file and automatically committing it with an AI code review step. This skill enforces single-file editing to maintain clean git history and uses roborev for pre-commit code review.
+
+## Prerequisites
+
+- roborev must be installed at `/Users/josh-gree/.local/bin/roborev`
+- Git repository must be initialised
+- Working directory should be clean or have only the file being edited modified
+
+## Workflow
+
+### Step 1: Identify the File and Change
+
+User will specify:
+- Which file to edit
+- What changes to make
+
+If not clear, ask for clarification.
+
+**STOP if:**
+- User requests changes to multiple files → "This skill edits one file at a time. Please specify a single file."
+- File path is ambiguous → Ask which file they mean
+
+### Step 2: Read the File
+
+Read the current file contents to understand context:
+
+```bash
+# Use Read tool to read the file
+```
+
+**STOP if:**
+- File doesn't exist → Ask if they want to create a new file (requires Write tool, not Edit)
+
+### Step 3: Make the Edit
+
+Use the Edit tool to make the requested changes to the file.
+
+Follow these principles:
+- Make only the requested changes
+- Preserve existing formatting and style
+- Don't add unnecessary comments or documentation
+- Don't refactor surrounding code unless requested
+
+### Step 4: Run roborev Pre-commit Review
+
+After editing but before committing, run roborev to review the changes:
+
+```bash
+/Users/josh-gree/.local/bin/roborev review --dirty --wait
+```
+
+The `--dirty` flag reviews uncommitted changes.
+The `--wait` flag blocks until the review completes.
+
+### Step 5: Display Review Results
+
+Show the roborev review results to the user:
+
+```bash
+/Users/josh-gree/.local/bin/roborev show HEAD
+```
+
+Explain any issues or suggestions found by roborev.
+
+### Step 6: User Decision
+
+Ask the user:
+- **Proceed with commit** - Changes look good, commit them
+- **Make adjustments** - Address roborev feedback first
+
+If adjustments needed, return to Step 3 with the additional changes.
+
+### Step 7: Commit the Changes
+
+Once user approves, commit the changes with a descriptive message:
+
+```bash
+git add <file-path>
+git commit -m "<descriptive commit message>"
+```
+
+**Commit message guidelines:**
+- Use present tense, imperative mood (e.g., "Add feature" not "Added feature")
+- Be specific about what changed
+- Focus on the "why" not just the "what"
+- Keep it concise (one line preferred, under 72 characters)
+- No Claude attribution per user's global CLAUDE.md
+
+**Examples:**
+- "Fix null pointer in user authentication"
+- "Add rate limiting to API endpoints"
+- "Refactor database connection pooling"
+- "Update error messages for clarity"
+
+### Step 8: Confirm Success
+
+Report back to user:
+- What file was edited
+- What changes were made
+- Commit SHA
+- Any roborev feedback that was addressed
+
+## Single-File Enforcement
+
+This skill is designed for atomic commits. If the user asks to edit multiple files:
+
+1. **Refuse the request** - Explain this skill handles one file at a time
+2. **Suggest alternatives**:
+   - Run the skill multiple times for separate files
+   - Use standard editing workflow for multi-file changes
+   - Consider if changes should be a single ticket with `/implement-ticket`
+
+## Guidelines
+
+**DO**:
+- Edit exactly one file per invocation
+- Read the file first to understand context
+- Run roborev review before committing
+- Show review results to user
+- Write clear, descriptive commit messages
+- Ask user to approve before committing
+
+**DON'T**:
+- Edit multiple files in one invocation
+- Skip the roborev review step
+- Commit without user approval after review
+- Add Claude attribution to commits
+- Make changes beyond what was requested
+- Refactor or "improve" code unless asked
+
+## Handling Issues
+
+**roborev not found:**
+Check if roborev is installed. The skill requires it at `/Users/josh-gree/.local/bin/roborev`.
+
+**roborev review fails:**
+Show the error to user and ask how to proceed. Can commit anyway with user approval.
+
+**Merge conflicts or dirty tree:**
+If there are other uncommitted changes, ask user to commit or stash them first, or proceed carefully.
+
+**Review finds serious issues:**
+Don't commit until issues are addressed or user explicitly approves anyway.
+
+## Usage Examples
+
+### Example 1: Fix a bug
+
+User: "Fix the null pointer in auth.py line 42"
+
+Skill response:
+1. Read auth.py
+2. Make the fix to line 42
+3. Run roborev review
+4. Show review results
+5. Ask user to approve
+6. Commit: "Fix null pointer in user authentication"
+
+### Example 2: Add a feature
+
+User: "Add logging to the database query function"
+
+Skill response:
+1. Read the file containing the database query function
+2. Add logging statements
+3. Run roborev review
+4. Review notes missing error handling
+5. Show review to user, ask if they want to add error handling too
+6. User approves proceeding
+7. Commit: "Add logging to database query function"
+
+### Example 3: Review finds issues
+
+User: "Update the API rate limit from 100 to 1000"
+
+Skill response:
+1. Read config file
+2. Change rate limit value
+3. Run roborev review
+4. Review warns this may cause performance issues
+5. Show warning to user
+6. User decides to use 500 instead
+7. Make adjustment
+8. Run roborev review again
+9. Review passes
+10. Commit: "Increase API rate limit to 500"
+
+## Checklist
+
+- [ ] Identify single file to edit and what changes to make
+- [ ] Read the file to understand context
+- [ ] Make the requested edits
+- [ ] Run roborev pre-commit review with --dirty --wait
+- [ ] Display review results to user
+- [ ] Get user approval to proceed or make adjustments
+- [ ] Commit with descriptive message (no Claude attribution)
+- [ ] Report success with commit SHA and summary


### PR DESCRIPTION
## Summary

Created a new skill `/edit-and-commit` that enforces atomic commits by:
- Restricting edits to a single file at a time
- Running roborev pre-commit review before committing
- Automatically committing with descriptive messages
- Following user's global commit guidelines (no Claude attribution)

The skill integrates roborev's code review functionality to catch issues before they're committed, whilst maintaining clean git history through single-file edits.

Closes #24